### PR TITLE
Add optional security with Auth0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,48 @@
+# Form137 API
+
+This project provides mock endpoints for the Form 137 system. By default it runs without authentication.
+
+## Auth0 Integration
+
+To secure the API with Auth0, enable the `auth` feature and configure the issuer URI.
+
+Set the following properties (for example in environment variables or a `application.yml` file):
+
+```
+AUTH0_ISSUER_URI=https://YOUR_AUTH0_DOMAIN/
+AUTH_ENABLED=true
+```
+
+### MongoDB Atlas
+
+Configure the connection string for your Atlas cluster using the standard
+Spring Boot properties:
+
+```
+SPRING_DATA_MONGODB_URI=mongodb+srv://<user>:<pass>@<cluster>.mongodb.net/form137?retryWrites=true&w=majority
+SPRING_DATA_MONGODB_DATABASE=form137
+```
+
+When `auth.enabled=true`, all endpoints except `/api/health/**` require a valid JWT issued by Auth0.
+
+For local development without authentication the default configuration keeps `auth.enabled=false`.
+
+## Running
+
+Use the provided Gradle tasks:
+
+```
+./gradlew bootRunDev         # runs with the dev profile
+./gradlew test              # runs unit tests
+```
+
+## Deploying to IKS
+
+Kubernetes manifests are provided in the `k8s` directory. Apply them to deploy the API
+on IBM Cloud Kubernetes Service. An ingress configuration can be added separately
+when needed.
+
+```bash
+kubectl apply -f k8s/deployment.yaml
+kubectl apply -f k8s/service.yaml
+```

--- a/build.gradle
+++ b/build.gradle
@@ -19,10 +19,12 @@ repositories {
 }
 
 dependencies {
-	implementation 'org.springframework.boot:spring-boot-starter-data-mongodb'
-	implementation 'org.springframework.boot:spring-boot-starter-validation'
-	implementation 'org.springframework.boot:spring-boot-starter-web'
-	implementation 'de.flapdoodle.embed:de.flapdoodle.embed.mongo.spring3x:4.20.0' // ← embedded
+        implementation 'org.springframework.boot:spring-boot-starter-data-mongodb'
+        implementation 'org.springframework.boot:spring-boot-starter-validation'
+        implementation 'org.springframework.boot:spring-boot-starter-web'
+        implementation 'org.springframework.boot:spring-boot-starter-security'
+        implementation 'org.springframework.boot:spring-boot-starter-oauth2-resource-server'
+        implementation 'de.flapdoodle.embed:de.flapdoodle.embed.mongo.spring3x:4.20.0' // ← embedded
         testImplementation 'org.springframework.boot:spring-boot-starter-test'
         testImplementation 'au.com.dius.pact.provider:junit5spring:4.6.10'
         testRuntimeOnly 'org.junit.platform:junit-platform-launcher'

--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -1,0 +1,28 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: form137-api
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: form137-api
+  template:
+    metadata:
+      labels:
+        app: form137-api
+    spec:
+      containers:
+        - name: form137-api
+          image: REPLACE_WITH_YOUR_REGISTRY/form137-api:latest
+          ports:
+            - containerPort: 8080
+          env:
+            - name: SPRING_PROFILES_ACTIVE
+              value: prod
+            - name: SPRING_DATA_MONGODB_URI
+              value: "mongodb+srv://user:password@cluster.mongodb.net/form137?retryWrites=true&w=majority"
+            - name: SPRING_DATA_MONGODB_DATABASE
+              value: form137
+            - name: AUTH0_ISSUER_URI
+              value: "https://YOUR_AUTH0_DOMAIN/"

--- a/k8s/service.yaml
+++ b/k8s/service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: form137-api
+spec:
+  selector:
+    app: form137-api
+  ports:
+    - port: 80
+      targetPort: 8080
+      protocol: TCP
+  type: ClusterIP

--- a/src/main/java/ph/edu/cspb/form137/config/SecurityConfig.java
+++ b/src/main/java/ph/edu/cspb/form137/config/SecurityConfig.java
@@ -1,0 +1,33 @@
+package ph.edu.cspb.form137.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.Customizer;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+public class SecurityConfig {
+
+    @Value("${auth.enabled:false}")
+    private boolean authEnabled;
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        if (authEnabled) {
+            http
+                .authorizeHttpRequests(authz -> authz
+                    .requestMatchers("/api/health/**").permitAll()
+                    .anyRequest().authenticated()
+                )
+                .oauth2ResourceServer(oauth2 -> oauth2.jwt(Customizer.withDefaults()));
+        } else {
+            http
+                .authorizeHttpRequests(authz -> authz.anyRequest().permitAll())
+                .csrf(AbstractHttpConfigurer::disable);
+        }
+        return http.build();
+    }
+}

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -9,3 +9,5 @@ de:
     mongodb:
       embedded:
         version: 7.0.5
+auth:
+  enabled: false

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -1,7 +1,14 @@
 spring:
   data:
     mongodb:
-      uri: ${MONGODB_URI}
-      database: ${MONGODB_DATABASE}
+      uri: ${SPRING_DATA_MONGODB_URI}
+      database: ${SPRING_DATA_MONGODB_DATABASE}
+  security:
+    oauth2:
+      resourceserver:
+        jwt:
+          issuer-uri: ${AUTH0_ISSUER_URI}
 server:
   port: 8080
+auth:
+  enabled: true

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,2 @@
 spring.application.name=form137-api
+auth.enabled=false


### PR DESCRIPTION
## Summary
- add Spring Security and resource server deps
- implement `SecurityConfig` with optional Auth0 JWT validation
- wire issuer URI via `AUTH0_ISSUER_URI` env var in production profile
- allow dev profile to run with auth disabled by default
- document Auth0 setup in the API project and run the application in the new README file
- provide Kubernetes deployment and service manifests for IKS
- update MongoDB Atlas environment variables

## Testing
- `./gradlew test --no-daemon`


------
https://chatgpt.com/codex/tasks/task_e_68761accedb083228d264edbc7832cf5