### PR TITLE
Add MongoDB entity and repository

### DIFF
--- a/src/main/java/ph/edu/cspb/form137/controller/Form137Controller.java
+++ b/src/main/java/ph/edu/cspb/form137/controller/Form137Controller.java
@@ -1,10 +1,13 @@
 package ph.edu.cspb.form137.controller;
 
+import java.time.Instant;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -12,56 +15,71 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import ph.edu.cspb.form137.model.Form137Request;
+import ph.edu.cspb.form137.repository.Form137RequestRepository;
 
 @RestController
 @RequestMapping("/api/form137")
 public class Form137Controller {
 
-    private String scenario = "success";
+    private final Form137RequestRepository repository;
 
-    public void setScenario(String scenario) {
-        this.scenario = scenario;
+    public Form137Controller(Form137RequestRepository repository) {
+        this.repository = repository;
     }
 
     @PostMapping(value = "/submit", consumes = MediaType.MULTIPART_FORM_DATA_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
-    public ResponseEntity<Map<String, Object>> submit() {
-        if ("invalid".equals(scenario)) {
+    public ResponseEntity<Map<String, Object>> submit(@ModelAttribute Form137Request request) {
+        Map<String, Object> errors = new HashMap<>();
+        if (request.getLearnerReferenceNumber() == null || !request.getLearnerReferenceNumber().matches("\\d{12}")) {
+            errors.put("learnerReferenceNumber", new String[]{"Must be exactly 12 digits"});
+        }
+        if (request.getFirstName() == null || request.getFirstName().isBlank()) {
+            errors.put("firstName", new String[]{"First name is required"});
+        }
+        if (request.getRequesterEmail() == null || !request.getRequesterEmail().contains("@")) {
+            errors.put("emailAddress", new String[]{"Please enter a valid email address"});
+        }
+        if (!errors.isEmpty()) {
             Map<String, Object> body = new HashMap<>();
             body.put("error", "Validation Error");
             body.put("message", "Form validation failed");
             body.put("statusCode", 400);
-            Map<String, Object> details = new HashMap<>();
-            details.put("learnerReferenceNumber", new String[]{"Must be exactly 12 digits"});
-            details.put("firstName", new String[]{"First name is required"});
-            details.put("emailAddress", new String[]{"Please enter a valid email address"});
-            body.put("details", details);
+            body.put("details", errors);
             return ResponseEntity.status(400).body(body);
         }
 
+        if (request.getTicketNumber() == null) {
+            request.setTicketNumber("REQ-" + Instant.now().toString().replaceAll("\\D", "").substring(0, 5));
+        }
+        request.setSubmittedAt(Instant.now().toString());
+        request.setStatus("processing");
+        Form137Request saved = repository.save(request);
+
         Map<String, Object> body = new HashMap<>();
         body.put("success", true);
-        String ticket = "self".equals(scenario) ? "REQ-2025-00124" : "REQ-2025-00123";
-        body.put("ticketNumber", ticket);
+        body.put("ticketNumber", saved.getTicketNumber());
         body.put("message", "Form 137 request submitted successfully");
-        body.put("submittedAt", "2025-01-11T21:52:11.000Z");
+        body.put("submittedAt", saved.getSubmittedAt());
         return ResponseEntity.status(201).body(body);
     }
 
     @GetMapping(value = "/status/{ticketNumber}", produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<Map<String, Object>> status(@PathVariable String ticketNumber) {
-        if ("REQ-2025-00123".equals(ticketNumber)) {
+        Optional<Form137Request> result = repository.findByTicketNumber(ticketNumber);
+        if (result.isEmpty()) {
             Map<String, Object> body = new HashMap<>();
-            body.put("ticketNumber", "REQ-2025-00123");
-            body.put("status", "processing");
-            body.put("submittedAt", "2025-01-11T21:52:11.000Z");
-            body.put("updatedAt", "2025-01-12T09:30:00.000Z");
-            body.put("notes", "Documents under review");
-            return ResponseEntity.ok(body);
+            body.put("error", "Not Found");
+            body.put("message", "Submission not found");
+            body.put("statusCode", 404);
+            return ResponseEntity.status(404).body(body);
         }
+        Form137Request req = result.get();
         Map<String, Object> body = new HashMap<>();
-        body.put("error", "Not Found");
-        body.put("message", "Submission not found");
-        body.put("statusCode", 404);
-        return ResponseEntity.status(404).body(body);
+        body.put("ticketNumber", req.getTicketNumber());
+        body.put("status", req.getStatus());
+        body.put("submittedAt", req.getSubmittedAt());
+        body.put("updatedAt", req.getUpdatedAt());
+        body.put("notes", req.getNotes());
+        return ResponseEntity.ok(body);
     }
 }

--- a/src/main/java/ph/edu/cspb/form137/model/Comment.java
+++ b/src/main/java/ph/edu/cspb/form137/model/Comment.java
@@ -1,0 +1,28 @@
+package ph.edu.cspb.form137.model;
+
+public class Comment {
+    private String id;
+    private String message;
+    private String registrarName;
+    private boolean requiresResponse;
+    private String timestamp;
+    private String type;
+
+    public String getId() { return id; }
+    public void setId(String id) { this.id = id; }
+
+    public String getMessage() { return message; }
+    public void setMessage(String message) { this.message = message; }
+
+    public String getRegistrarName() { return registrarName; }
+    public void setRegistrarName(String registrarName) { this.registrarName = registrarName; }
+
+    public boolean isRequiresResponse() { return requiresResponse; }
+    public void setRequiresResponse(boolean requiresResponse) { this.requiresResponse = requiresResponse; }
+
+    public String getTimestamp() { return timestamp; }
+    public void setTimestamp(String timestamp) { this.timestamp = timestamp; }
+
+    public String getType() { return type; }
+    public void setType(String type) { this.type = type; }
+}

--- a/src/main/java/ph/edu/cspb/form137/model/Form137Request.java
+++ b/src/main/java/ph/edu/cspb/form137/model/Form137Request.java
@@ -1,6 +1,29 @@
 package ph.edu.cspb.form137.model;
 
+import java.util.List;
+
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+/**
+ * MongoDB entity representing a Form 137 request submission.
+ * <p>
+ * The connection details are provided via the {@code SPRING_DATA_MONGODB_URI}
+ * and {@code SPRING_DATA_MONGODB_DATABASE} environment variables.
+ * </p>
+ */
+@Document(collection = "form137_requests")
 public class Form137Request {
+
+    @Id
+    private String id;
+    private String ticketNumber;
+    private String status;
+    private String submittedAt;
+    private String updatedAt;
+    private String notes;
+    private List<Comment> comments;
+
     private String learnerReferenceNumber;
     private String firstName;
     private String middleName;
@@ -11,12 +34,35 @@ public class Form137Request {
     private String previousSchool;
     private String purposeOfRequest;
     private String deliveryMethod;
+    private String estimatedCompletion;
+    private String requestType;
+    private String learnerName;
     private String requesterName;
     private String relationshipToLearner;
-    private String emailAddress;
+    private String requesterEmail;
     private String mobileNumber;
 
     // getters and setters
+    public String getId() { return id; }
+    public void setId(String id) { this.id = id; }
+
+    public String getTicketNumber() { return ticketNumber; }
+    public void setTicketNumber(String ticketNumber) { this.ticketNumber = ticketNumber; }
+
+    public String getStatus() { return status; }
+    public void setStatus(String status) { this.status = status; }
+
+    public String getSubmittedAt() { return submittedAt; }
+    public void setSubmittedAt(String submittedAt) { this.submittedAt = submittedAt; }
+
+    public String getUpdatedAt() { return updatedAt; }
+    public void setUpdatedAt(String updatedAt) { this.updatedAt = updatedAt; }
+
+    public String getNotes() { return notes; }
+    public void setNotes(String notes) { this.notes = notes; }
+
+    public List<Comment> getComments() { return comments; }
+    public void setComments(List<Comment> comments) { this.comments = comments; }
     public String getLearnerReferenceNumber() { return learnerReferenceNumber; }
     public void setLearnerReferenceNumber(String learnerReferenceNumber) { this.learnerReferenceNumber = learnerReferenceNumber; }
     public String getFirstName() { return firstName; }
@@ -37,12 +83,18 @@ public class Form137Request {
     public void setPurposeOfRequest(String purposeOfRequest) { this.purposeOfRequest = purposeOfRequest; }
     public String getDeliveryMethod() { return deliveryMethod; }
     public void setDeliveryMethod(String deliveryMethod) { this.deliveryMethod = deliveryMethod; }
+    public String getEstimatedCompletion() { return estimatedCompletion; }
+    public void setEstimatedCompletion(String estimatedCompletion) { this.estimatedCompletion = estimatedCompletion; }
+    public String getRequestType() { return requestType; }
+    public void setRequestType(String requestType) { this.requestType = requestType; }
+    public String getLearnerName() { return learnerName; }
+    public void setLearnerName(String learnerName) { this.learnerName = learnerName; }
     public String getRequesterName() { return requesterName; }
     public void setRequesterName(String requesterName) { this.requesterName = requesterName; }
     public String getRelationshipToLearner() { return relationshipToLearner; }
     public void setRelationshipToLearner(String relationshipToLearner) { this.relationshipToLearner = relationshipToLearner; }
-    public String getEmailAddress() { return emailAddress; }
-    public void setEmailAddress(String emailAddress) { this.emailAddress = emailAddress; }
+    public String getRequesterEmail() { return requesterEmail; }
+    public void setRequesterEmail(String requesterEmail) { this.requesterEmail = requesterEmail; }
     public String getMobileNumber() { return mobileNumber; }
     public void setMobileNumber(String mobileNumber) { this.mobileNumber = mobileNumber; }
 }

--- a/src/main/java/ph/edu/cspb/form137/repository/Form137RequestRepository.java
+++ b/src/main/java/ph/edu/cspb/form137/repository/Form137RequestRepository.java
@@ -1,0 +1,12 @@
+package ph.edu.cspb.form137.repository;
+
+import org.springframework.data.mongodb.repository.MongoRepository;
+import ph.edu.cspb.form137.model.Form137Request;
+import java.util.Optional;
+
+/**
+ * Repository for {@link Form137Request} documents.
+ */
+public interface Form137RequestRepository extends MongoRepository<Form137Request, String> {
+    Optional<Form137Request> findByTicketNumber(String ticketNumber);
+}

--- a/src/test/java/ph/edu/cspb/form137/Form137ApiApplicationTests.java
+++ b/src/test/java/ph/edu/cspb/form137/Form137ApiApplicationTests.java
@@ -2,6 +2,8 @@ package ph.edu.cspb.form137;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import ph.edu.cspb.form137.repository.Form137RequestRepository;
 
 /**
  * Basic context load test.
@@ -9,10 +11,20 @@ import org.springframework.boot.test.context.SpringBootTest;
  * downloading the MongoDB binary during tests, which can fail in
  * restricted environments.</p>
  */
-@SpringBootTest(properties =
+@SpringBootTest(properties = {
         "spring.autoconfigure.exclude=" +
-        "de.flapdoodle.embed.mongo.spring.autoconfigure.EmbeddedMongoAutoConfiguration")
+                "de.flapdoodle.embed.mongo.spring.autoconfigure.EmbeddedMongoAutoConfiguration," +
+                "org.springframework.boot.autoconfigure.mongo.MongoAutoConfiguration," +
+                "org.springframework.boot.autoconfigure.data.mongo.MongoDataAutoConfiguration," +
+                "org.springframework.boot.autoconfigure.data.mongo.MongoRepositoriesAutoConfiguration," +
+                "org.springframework.boot.autoconfigure.security.oauth2.resource.servlet.OAuth2ResourceServerAutoConfiguration",
+        "auth.enabled=false",
+        "spring.security.oauth2.resourceserver.jwt.issuer-uri="
+})
 class Form137ApiApplicationTests {
+
+    @MockBean
+    Form137RequestRepository repository;
 
     @Test
     void contextLoads() {

--- a/src/test/java/ph/edu/cspb/form137/pact/DashboardApiProviderPactTest.java
+++ b/src/test/java/ph/edu/cspb/form137/pact/DashboardApiProviderPactTest.java
@@ -11,16 +11,33 @@ import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import static org.mockito.Mockito.*;
+
+import ph.edu.cspb.form137.model.Comment;
+import ph.edu.cspb.form137.model.Form137Request;
+import ph.edu.cspb.form137.repository.Form137RequestRepository;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
-        properties = "spring.autoconfigure.exclude=" +
-                "de.flapdoodle.embed.mongo.spring.autoconfigure.EmbeddedMongoAutoConfiguration")
+        properties = {
+                "spring.autoconfigure.exclude=" +
+                        "de.flapdoodle.embed.mongo.spring.autoconfigure.EmbeddedMongoAutoConfiguration," +
+                        "org.springframework.boot.autoconfigure.mongo.MongoAutoConfiguration," +
+                        "org.springframework.boot.autoconfigure.data.mongo.MongoDataAutoConfiguration," +
+                        "org.springframework.boot.autoconfigure.data.mongo.MongoRepositoriesAutoConfiguration," +
+                        "org.springframework.boot.autoconfigure.security.oauth2.resource.servlet.OAuth2ResourceServerAutoConfiguration",
+                "auth.enabled=false",
+                "spring.security.oauth2.resourceserver.jwt.issuer-uri="
+        })
 @Provider("DashboardAPI")
 @PactFolder("pacts")
 class DashboardApiProviderPactTest {
 
     @LocalServerPort
     private int port;
+
+    @MockBean
+    Form137RequestRepository repository;
 
     @BeforeEach
     void before(PactVerificationContext context) {
@@ -34,14 +51,46 @@ class DashboardApiProviderPactTest {
     }
 
     @State("user has form 137 requests")
-    public void userHasRequests() {}
+    public void userHasRequests() {
+        Comment comment = new Comment();
+        comment.setId("comment_001");
+        comment.setMessage("Your request has been received");
+        comment.setRegistrarName("Ms. Santos");
+        comment.setRequiresResponse(false);
+        comment.setTimestamp("2024-01-15T10:35:00Z");
+        comment.setType("info");
+
+        Form137Request req = new Form137Request();
+        req.setId("req_001");
+        req.setTicketNumber("F137-2024-001");
+        req.setStatus("submitted");
+        req.setSubmittedAt("2024-01-15T10:30:00Z");
+        req.setDeliveryMethod("pickup");
+        req.setEstimatedCompletion("2024-01-22T17:00:00Z");
+        req.setLearnerName("Juan Dela Cruz");
+        req.setLearnerReferenceNumber("123456789012");
+        req.setRequestType("Original Copy");
+        req.setRequesterEmail("maria@email.com");
+        req.setRequesterName("Maria Dela Cruz");
+        req.setComments(java.util.List.of(comment));
+
+        when(repository.findAll()).thenReturn(java.util.List.of(req));
+        when(repository.findById("req_001")).thenReturn(java.util.Optional.of(req));
+    }
 
     @State("request does not exist")
-    public void requestDoesNotExist() {}
+    public void requestDoesNotExist() {
+        when(repository.findById("nonexistent")).thenReturn(java.util.Optional.empty());
+    }
 
     @State("request exists")
-    public void requestExists() {}
+    public void requestExists() {
+        userHasRequests();
+    }
 
     @State("request exists and accepts comments")
-    public void requestExistsAndAcceptsComments() {}
+    public void requestExistsAndAcceptsComments() {
+        userHasRequests();
+        when(repository.save(any(Form137Request.class))).thenAnswer(i -> i.getArgument(0));
+    }
 }

--- a/src/test/java/ph/edu/cspb/form137/pact/Form137ApiProviderPactTest.java
+++ b/src/test/java/ph/edu/cspb/form137/pact/Form137ApiProviderPactTest.java
@@ -11,13 +11,23 @@ import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.server.LocalServerPort;
-import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import static org.mockito.Mockito.*;
 
-import ph.edu.cspb.form137.controller.Form137Controller;
+import ph.edu.cspb.form137.model.Form137Request;
+import ph.edu.cspb.form137.repository.Form137RequestRepository;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
-        properties = "spring.autoconfigure.exclude=" +
-                "de.flapdoodle.embed.mongo.spring.autoconfigure.EmbeddedMongoAutoConfiguration")
+        properties = {
+                "spring.autoconfigure.exclude=" +
+                        "de.flapdoodle.embed.mongo.spring.autoconfigure.EmbeddedMongoAutoConfiguration," +
+                        "org.springframework.boot.autoconfigure.mongo.MongoAutoConfiguration," +
+                        "org.springframework.boot.autoconfigure.data.mongo.MongoDataAutoConfiguration," +
+                        "org.springframework.boot.autoconfigure.data.mongo.MongoRepositoriesAutoConfiguration," +
+                        "org.springframework.boot.autoconfigure.security.oauth2.resource.servlet.OAuth2ResourceServerAutoConfiguration",
+                "auth.enabled=false",
+                "spring.security.oauth2.resourceserver.jwt.issuer-uri="
+        })
 @Provider("Form137API")
 @PactFolder("pacts")
 class Form137ApiProviderPactTest {
@@ -25,8 +35,8 @@ class Form137ApiProviderPactTest {
     @LocalServerPort
     private int port;
 
-    @Autowired
-    Form137Controller controller;
+    @MockBean
+    Form137RequestRepository repository;
 
     @BeforeEach
     void before(PactVerificationContext context) {
@@ -41,26 +51,38 @@ class Form137ApiProviderPactTest {
 
     @State("API is available for form submission")
     public void apiAvailableForSubmission() {
-        controller.setScenario("success");
+        Form137Request saved = new Form137Request();
+        saved.setTicketNumber("REQ-2025-00123");
+        saved.setSubmittedAt("2025-01-11T21:52:11.000Z");
+        when(repository.save(any(Form137Request.class))).thenReturn(saved);
     }
 
     @State("API is available for self-requester form submission")
     public void apiAvailableForSelfSubmission() {
-        controller.setScenario("self");
+        Form137Request saved = new Form137Request();
+        saved.setTicketNumber("REQ-2025-00124");
+        saved.setSubmittedAt("2025-01-11T21:52:11.000Z");
+        when(repository.save(any(Form137Request.class))).thenReturn(saved);
     }
 
     @State("API validates form data")
     public void apiValidatesFormData() {
-        controller.setScenario("invalid");
+        // no repository interaction needed
     }
 
     @State("A form submission exists with ticket number REQ-2025-00123")
     public void submissionExists() {
-        controller.setScenario("success");
+        Form137Request req = new Form137Request();
+        req.setTicketNumber("REQ-2025-00123");
+        req.setStatus("processing");
+        req.setSubmittedAt("2025-01-11T21:52:11.000Z");
+        req.setUpdatedAt("2025-01-12T09:30:00.000Z");
+        req.setNotes("Documents under review");
+        when(repository.findByTicketNumber("REQ-2025-00123")).thenReturn(java.util.Optional.of(req));
     }
 
     @State("No form submission exists with ticket number REQ-2025-99999")
     public void submissionDoesNotExist() {
-        controller.setScenario("missing");
+        when(repository.findByTicketNumber("REQ-2025-99999")).thenReturn(java.util.Optional.empty());
     }
 }


### PR DESCRIPTION
## Summary
- introduce `Form137Request` document
- add `Form137RequestRepository`
- read and write `Form137Request` data in controllers instead of returning hardcoded content
- update provider tests to mock the repository

## Testing
- `./gradlew test --no-daemon` *(fails: DashboardApiProviderPactTest, Form137ApiProviderPactTest)*

------
https://chatgpt.com/codex/tasks/task_e_6877b4f206188322afeee26ed3308eec