### PR TITLE
Allow form137.cspb.edu.ph origin

### DIFF
--- a/src/main/java/ph/edu/cspb/form137/config/CorsConfig.java
+++ b/src/main/java/ph/edu/cspb/form137/config/CorsConfig.java
@@ -9,8 +9,8 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 @Configuration
 public class CorsConfig {
 
-    @Value("${cors.allowed-origin:https://form137.cspb.edu.ph}")
-    private String allowedOrigin;
+    @Value("${cors.allowed-origins:https://form137.cspb.edu.ph}")
+    private String[] allowedOrigins;
 
     @Bean
     public WebMvcConfigurer corsConfigurer() {
@@ -18,7 +18,7 @@ public class CorsConfig {
             @Override
             public void addCorsMappings(CorsRegistry registry) {
                 registry.addMapping("/**")
-                        .allowedOrigins(allowedOrigin)
+                        .allowedOrigins(allowedOrigins)
                         .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")
                         .allowCredentials(true);
             }

--- a/src/main/java/ph/edu/cspb/form137/config/SecurityConfig.java
+++ b/src/main/java/ph/edu/cspb/form137/config/SecurityConfig.java
@@ -22,11 +22,13 @@ public class SecurityConfig {
                     .requestMatchers("/api/health/**").permitAll()
                     .anyRequest().authenticated()
                 )
-                .oauth2ResourceServer(oauth2 -> oauth2.jwt(Customizer.withDefaults()));
+                .oauth2ResourceServer(oauth2 -> oauth2.jwt(Customizer.withDefaults()))
+                .cors(Customizer.withDefaults());
         } else {
             http
                 .authorizeHttpRequests(authz -> authz.anyRequest().permitAll())
-                .csrf(AbstractHttpConfigurer::disable);
+                .csrf(AbstractHttpConfigurer::disable)
+                .cors(Customizer.withDefaults());
         }
         return http.build();
     }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,3 +1,3 @@
 spring.application.name=form137-api
 auth.enabled=false
-cors.allowed-origin=https://form137.cspb.edu.ph
+cors.allowed-origins=https://form137.cspb.edu.ph


### PR DESCRIPTION
## Summary
- allow multiple CORS origins
- default to https://form137.cspb.edu.ph
- enable CORS support in the security filter

## Testing
- `./gradlew test --no-daemon`


------
https://chatgpt.com/codex/tasks/task_e_687a800cfbec832284de02f610c40913